### PR TITLE
fix: auto import tsconfig-paths/register.js

### DIFF
--- a/src/baseCommand.ts
+++ b/src/baseCommand.ts
@@ -229,9 +229,10 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       this.env.TS_NODE_FILES = process.env.TS_NODE_FILES ?? 'true';
       // keep same logic with egg-core, test cmd load files need it
       // see https://github.com/eggjs/egg-core/blob/master/lib/loader/egg_loader.js#L49
-      // addNodeOptionsToEnv(`--require ${importResolve('tsconfig-paths/register', {
-      //   paths: [ getSourceDirname() ],
-      // })}`, ctx.env);
+      const tsConfigPathsRegister = importResolve('tsconfig-paths/register.js', {
+        paths: [ getSourceDirname() ],
+      });
+      this.addNodeOptions(this.formatImportModule(tsConfigPathsRegister));
     }
     if (this.isESM) {
       // use ts-node/esm loader on esm

--- a/test/commands/cov.test.ts
+++ b/test/commands/cov.test.ts
@@ -56,7 +56,7 @@ describe('test/commands/cov.test.ts', () => {
       await coffee.fork(eggBin, [ 'cov' ], { cwd })
         // .debug()
         .expect('stdout', /should work/)
-        .expect('stdout', /1 passing/)
+        .expect('stdout', /3 passing/)
         .expect('stdout', /Statements\s+: 100% \( \d+\/\d+ \)/)
         .expect('code', 0)
         .end();

--- a/test/commands/test.test.ts
+++ b/test/commands/test.test.ts
@@ -63,9 +63,9 @@ describe('test/commands/test.test.ts', () => {
     it('should success on ts', async () => {
       const cwd = getFixtures('example-ts');
       await coffee.fork(eggBin, [ 'test' ], { cwd })
-        // .debug()
+        .debug()
         .expect('stdout', /should work/)
-        .expect('stdout', /1 passing/)
+        .expect('stdout', /3 passing \(/)
         .expect('code', 0)
         .end();
     });

--- a/test/fixtures/example-ts/app/controller/home.ts
+++ b/test/fixtures/example-ts/app/controller/home.ts
@@ -1,9 +1,14 @@
 import { Controller } from 'egg';
-
+import { Foo } from '@/module/foo';
 export default class HomeController extends Controller {
   public async index() {
     const obj: PlainObject = {};
     obj.text = 'hi, egg';
     this.ctx.body = obj.text;
+  }
+
+  async foo() {
+    const instance = new Foo();
+    this.ctx.body = instance.bar();
   }
 }

--- a/test/fixtures/example-ts/app/module/foo.ts
+++ b/test/fixtures/example-ts/app/module/foo.ts
@@ -1,0 +1,5 @@
+export class Foo {
+  public bar() {
+    return 'bar';
+  }
+}

--- a/test/fixtures/example-ts/app/module/package.json
+++ b/test/fixtures/example-ts/app/module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "eggModule": {
+    "name": "foo"  
+  }
+}

--- a/test/fixtures/example-ts/app/router.ts
+++ b/test/fixtures/example-ts/app/router.ts
@@ -2,4 +2,5 @@ import { Application } from 'egg';
 
 export default (app: Application) => {
   app.router.get('/', app.controller.home.index);
+  app.router.get('/foo', app.controller.home.foo);
 };

--- a/test/fixtures/example-ts/package.json
+++ b/test/fixtures/example-ts/package.json
@@ -4,6 +4,6 @@
     "typescript": true
   },
   "devDependencies": {
-    "@eggjs/mock": "beta"
+    "@eggjs/mock": "6"
   }
 }

--- a/test/fixtures/example-ts/test/index.test.ts
+++ b/test/fixtures/example-ts/test/index.test.ts
@@ -1,12 +1,26 @@
-// @ts-ignore
+import { strict as assert } from 'node:assert';
 import { app } from '@eggjs/mock/bootstrap';
+import { Foo } from '@/module/foo'
 
-describe('test/index.test.ts', () => {
+describe('example-ts/test/index.test.ts', () => {
   it('should work', async () => {
     await app.ready();
     await app.httpRequest()
       .get('/')
       .expect('hi, egg')
       .expect(200);
+  });
+
+  it('should paths work', async () => {
+    await app.ready();
+    await app.httpRequest()
+      .get('/foo')
+      .expect('bar')
+      .expect(200);
+  });
+
+  it('should auto import tsconfig-paths/register', async () => {
+    const instance = new Foo();
+    assert.equal(instance.bar(), 'bar');
   });
 });

--- a/test/fixtures/example-ts/tsconfig.json
+++ b/test/fixtures/example-ts/tsconfig.json
@@ -1,3 +1,13 @@
 {
-  "extends": "@eggjs/tsconfig"
+  "extends": "@eggjs/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": false,
+    "paths": {
+      "@/module/*": ["./app/module/*"]
+    },
+    "baseUrl": "."
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `/foo` route in the application.
	- Introduced a `Foo` class with a `bar` method.
	- Enhanced TypeScript path resolution configuration.

- **Tests**
	- Updated test cases to cover new functionality, including the `/foo` endpoint.
	- Improved test suite with additional assertions and updated expected outputs.
	- Updated mock dependency to version 6.

- **Chores**
	- Updated TypeScript compiler settings to target ES2022 and refined module resolution strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->